### PR TITLE
add pigz compressor

### DIFF
--- a/DAB.pm
+++ b/DAB.pm
@@ -876,11 +876,15 @@ sub finalize {
 	zst => 'zstd --rm -9',
 	zstd => 'zstd --rm -9',
 	'zstd-max' => 'zstd --rm -19 -T0', # maximal level where the decompressor can still run efficiently
+	'pigz-fast' => 'pigz -1',
+	'pigz' => 'pigz',
     };
     my $compressor2ending = {
 	gzip => 'gz',
 	zstd => 'zst',
 	'zstd-max' => 'zst',
+	'pigz-fast' => 'gz',
+	'pigz' => 'gz',
     };
     my $compressor_cmd = $compressor2cmd_map->{$compressor};
     die "unkown compressor '$compressor', use one of: ". join(', ', sort keys %$compressor2cmd_map)


### PR DESCRIPTION
pigz is a fast and efficient compression algorithm.

**Comparison show that it is the best algorithm when throughput matter :**

![image](https://user-images.githubusercontent.com/15073640/203663860-3117da1b-6162-4186-871e-4cd94984ed30.png)
[source](https://community.centminmod.com/threads/round-3-compression-comparison-benchmarks-zstd-vs-brotli-vs-pigz-vs-bzip2-vs-xz-etc.17259/)

DAB can be used for continuous integration, and it that context speed matter (and so throughput !

This PR add 2 pigz compressor backed: one with default backend and another for fastest.